### PR TITLE
Don't try to merge undefined Broccoli tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,11 +27,18 @@ module.exports = {
   },
 
   treeForVendor(vendorTree) {
+    var trees = [];
     var hammertimeTree = new Funnel(path.dirname(require.resolve('hammer-timejs/hammer-time.js')), {
       files: ['hammer-time.js'],
     });
 
-    return new MergeTrees([vendorTree, hammertimeTree]);
+    if (vendorTree !== undefined) {
+      trees.push(vendorTree);
+    }
+    
+    trees.push(hammertimeTree);
+    
+    return new MergeTrees(trees);
   },
 
   isDevelopingAddon: function() {


### PR DESCRIPTION
ember-hammertime depends on broccoli-manager which depends on broccoli-plugin.

@stefanpenner committed to broccoli-plugin v1.3.0 on Oct 12, 2015, to:
    "validate inputNodes, disallow impossible node types"
    https://github.com/broccolijs/broccoli-plugin/commit/d5b9312f6c99b24b6955c43b585f22673497d229 (index.js)

and then  @joliss committed on Nov 2, 2015, to
   "Minor cleanup"
   https://github.com/broccolijs/broccoli-plugin/commit/9a9054db15137d0a1d51562aa25c62a6f9da5393

if pass [undefined, hammertimeTree] to MergeTrees() would cause an error:
   TypeError: BroccoliMergeTrees: Expected Broccoli node, got undefined for inputNodes[0]

I not know the reason why vendorTree is undefined, kindly share your idea if you know.